### PR TITLE
handle multibyte dtypes

### DIFF
--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -2,6 +2,7 @@ import io
 import logging
 import os
 import warnings
+import sys
 from hashlib import sha256
 from glob import has_magic
 
@@ -1364,7 +1365,7 @@ class AbstractBufferedFile(io.IOBase):
 
         https://docs.python.org/3/library/io.html#io.RawIOBase.readinto
         """
-        data = self.read(len(b))
+        data = self.read(len(b)*sys.getsizeof(b))
         memoryview(b).cast("B")[: len(data)] = data
         return len(data)
 

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -1365,7 +1365,7 @@ class AbstractBufferedFile(io.IOBase):
 
         https://docs.python.org/3/library/io.html#io.RawIOBase.readinto
         """
-        data = self.read(len(b)*sys.getsizeof(b))
+        data = self.read(len(bytearray(b)))
         memoryview(b).cast("B")[: len(data)] = data
         return len(data)
 

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -2,7 +2,6 @@ import io
 import logging
 import os
 import warnings
-import sys
 from hashlib import sha256
 from glob import has_magic
 


### PR DESCRIPTION
First off thank you so much for fsspec and all the work it entailed! 
We think we have a fix for a small bug.

We ran into the following problem.
When we execute this script: 
``` python
from s3fs import S3FileSystem
from tifffile import imread

fs = S3FileSystem(anon=True)
with fs.open("s3://aics-modeling-packages-test-resources/aicsimageio/test_resources/resources/s_1_t_1_c_1_z_1.tiff") as open_resource:
    print(type(open_resource))
    print(imread(open_resource).shape)
```

we encounter the following exception:
```
<class 's3fs.core.S3File'>
Traceback (most recent call last):
  File "/Users/jamies/Library/Application Support/JetBrains/PyCharm2020.1/scratches/scratch_13.py", line 14, in <module>
    print(imread(open_resource).shape)
  File "/Users/jamies/Sandbox/Scratch/Jackson/tifffile/tifffile/tifffile.py", line 721, in imread
    return tif.asarray(**kwargs)
  File "/Users/jamies/Sandbox/Scratch/Jackson/tifffile/tifffile/tifffile.py", line 2804, in asarray
    result = self.filehandle.read_array(
  File "/Users/jamies/Sandbox/Scratch/Jackson/tifffile/tifffile/tifffile.py", line 7498, in read_array
    raise ValueError(f'failed to read {size} bytes')
ValueError: failed to read 308750 bytes

Process finished with exit code 1
```

When we traced it back it seems to be the read() in readinto() doesn't seem to allow for array types of more than 1 byte. 

I've run the local tests and they pass.

The test `test_readinto_with_numpy` seems to operate on _io.BufferedReader not the AbstractBufferedFile. 